### PR TITLE
feat: making the build script optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'Jacky Efendi'
 inputs:
   build-script:
     description: 'Optional — The build script for your project. Will be run before running bundlewatch'
-    required: true
+    required: false
 
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Run bundlewatch against your PR to keep those bundles in check! Up
 author: 'Jacky Efendi'
 inputs:
   build-script:
-    description: 'The build script for your project. Will be run before running bundlewatch'
+    description: 'Optional — The build script for your project. Will be run before running bundlewatch'
     required: true
 
 runs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,10 @@ async function run() {
     core.exportVariable('CI_BRANCH', branchName);
     core.exportVariable('BUNDLEWATCH_GITHUB_TOKEN', bundlesizeGithubToken);
 
-    console.log(`Running build script: "${buildScript}"`);
-    await exec.exec(`${buildScript}`, undefined);
+    if(buildScript) {
+      console.log(`Running build script: "${buildScript}"`);
+      await exec.exec(`${buildScript}`, undefined);
+    }
 
     console.log(`Running: bundlewatch`);
     await exec.exec(`npx bundlewatch`, undefined);


### PR DESCRIPTION
Hey! Thanks for this!

In many workflows, the build may have already been run, so it might be a good idea to make the `buildScript` an optional parameter.