### PR TITLE
fix: Add missing declaration for "bundlewatch-github-token" input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: 'Bundlewatch Github Action'
 description: 'Run bundlewatch against your PR to keep those bundles in check! Update your package.json according to bundlewatch config'
 author: 'Jacky Efendi'
 inputs:
+  bundlewatch-github-token:
+    description: 'A token to authenticate with the Bundlewatch service. Set this as a secret in your GitHub repository'
+    required: true
   build-script:
     description: 'Optional — The build script for your project. Will be run before running bundlewatch'
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ export const getBranchNameFromRef = (ref: string) => {
 async function run() {
   try {
     const buildScript = core.getInput('build-script');
-    const bundlesizeGithubToken = core.getInput('bundlewatch-github-token');
+    const bundlewatchGithubToken = core.getInput('bundlewatch-github-token');
 
     const githubPayload = github.context.payload;
 
@@ -26,7 +26,7 @@ async function run() {
     core.exportVariable('CI_REPO_NAME', repoName);
     core.exportVariable('CI_COMMIT_SHA', commitSHA);
     core.exportVariable('CI_BRANCH', branchName);
-    core.exportVariable('BUNDLEWATCH_GITHUB_TOKEN', bundlesizeGithubToken);
+    core.exportVariable('BUNDLEWATCH_GITHUB_TOKEN', bundlewatchGithubToken);
 
     if (buildScript) {
       console.log(`Running build script: "${buildScript}"`);


### PR DESCRIPTION
Hi and thanks for this!

I noticed that when the action runs it complains about an undeclared input:

```
##[warning]Unexpected input 'bundlewatch-github-token', valid inputs are ['build-script']
```

I assume that we need to declare the input in the action file, so I made a PR that does this. Let me know what you think!