### PR TITLE
Upgrade node in github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
We currently have a deprecation warning in the CI where we use your action.
![image](https://user-images.githubusercontent.com/15926755/195806162-149118f7-59d3-4abd-8796-1b35383e1e20.png)
Tell me if something's wrong with my pull request!
